### PR TITLE
initial attempt at fixing gradient

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -20,7 +20,7 @@ export default function Index({ posts, globalData }) {
 
   return (
     <Layout>
-      <div className={styles.wrapper}>
+      <div className={`${styles.wrapper} before:bg-white before:bg-white before:backdrop-blur-lg before:dark:bg-black before:dark:bg-opacity-30 before:bg-opacity-10 `}>
         <DynamicReactPlayer
           ref={videoPlayerRef}
           playsinline={true}

--- a/styles/player.module.css
+++ b/styles/player.module.css
@@ -20,7 +20,8 @@
     right: 0;
     bottom: 0;
     /* Transition from a solid color at the top to transparent at the bottom */
-    background: linear-gradient(to top, rgba(255, 255, 255, 0.99), rgba(255, 255, 255, 0.75));
+    /* background: linear-gradient(to top, rgba(255, 255, 255, 0.99), rgba(255, 255, 255, 0.75)); */
+    opacity: var(--tw-bg-opacity);
     pointer-events: none;  /* Ensure the video controls are still accessible */
 }
 


### PR DESCRIPTION
- added pseudo element before to classNames on div for video player (more [info](https://tailwindcss.com/docs/hover-focus-and-other-states) about this from tw docs)
- #2 
- added variable opacity to video player styling
- commented out the styling gradient that only matched light mode previously 